### PR TITLE
Update dependence react-tap-event-plugin

### DIFF
--- a/part-1-creating-components/package.json
+++ b/part-1-creating-components/package.json
@@ -20,7 +20,7 @@
     "react": "^15.3.2",
     "react-dom": "^15.3.2",
     "react-router": "^3.0.0",
-    "react-tap-event-plugin": "^1.0.0",
+    "react-tap-event-plugin": "^2.0.1",
     "validator": "^6.1.0"
   },
   "devDependencies": {

--- a/part-2-json-web-token/package.json
+++ b/part-2-json-web-token/package.json
@@ -25,7 +25,7 @@
     "react": "^15.3.2",
     "react-dom": "^15.3.2",
     "react-router": "^3.0.0",
-    "react-tap-event-plugin": "^1.0.0",
+    "react-tap-event-plugin": "^2.0.1",
     "validator": "^6.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
[react-tap-event-plugin](https://github.com/zilverline/react-tap-event-plugin) ^1.0.0 not work with react 0.15.4 and above.